### PR TITLE
Add drag-to-reorder and folder support to QuickLaunch grid

### DIFF
--- a/app/src/main/java/com/mindfulhome/data/AppDao.kt
+++ b/app/src/main/java/com/mindfulhome/data/AppDao.kt
@@ -184,6 +184,37 @@ interface QuickLaunchDao {
 
     @Query("SELECT COALESCE(MAX(position), -1) FROM quick_launch_items")
     suspend fun maxPosition(): Int
+
+    @Query("UPDATE quick_launch_items SET position = :position WHERE packageName = :packageName")
+    suspend fun updatePosition(packageName: String, position: Int)
+
+    @Query("UPDATE quick_launch_items SET folderId = :folderId WHERE packageName = :packageName")
+    suspend fun setFolder(packageName: String, folderId: Long?)
+
+    @Query("SELECT * FROM quick_launch_items WHERE folderId = :folderId ORDER BY position")
+    suspend fun getInFolderOnce(folderId: Long): List<QuickLaunchItem>
+
+    @Query("SELECT COUNT(*) FROM quick_launch_items WHERE folderId = :folderId")
+    suspend fun countInFolder(folderId: Long): Int
+}
+
+@Dao
+interface QuickLaunchFolderDao {
+
+    @Query("SELECT * FROM ql_folders ORDER BY position")
+    fun getAll(): Flow<List<QuickLaunchFolder>>
+
+    @Insert
+    suspend fun insert(folder: QuickLaunchFolder): Long
+
+    @Query("DELETE FROM ql_folders WHERE id = :folderId")
+    suspend fun delete(folderId: Long)
+
+    @Query("UPDATE ql_folders SET name = :name WHERE id = :id")
+    suspend fun rename(id: Long, name: String)
+
+    @Query("UPDATE ql_folders SET position = :position WHERE id = :id")
+    suspend fun updatePosition(id: Long, position: Int)
 }
 
 data class SessionLogWithCount(

--- a/app/src/main/java/com/mindfulhome/data/AppDatabase.kt
+++ b/app/src/main/java/com/mindfulhome/data/AppDatabase.kt
@@ -20,8 +20,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         SessionLog::class,
         SessionLogEvent::class,
         QuickLaunchItem::class,
+        QuickLaunchFolder::class,
     ],
-    version = 11,
+    version = 12,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -35,6 +36,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun todoDao(): TodoDao
     abstract fun sessionLogDao(): SessionLogDao
     abstract fun quickLaunchDao(): QuickLaunchDao
+    abstract fun quickLaunchFolderDao(): QuickLaunchFolderDao
 
     companion object {
         @Volatile
@@ -174,6 +176,19 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_11_12 = object : Migration(11, 12) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE quick_launch_items ADD COLUMN folderId INTEGER")
+                db.execSQL(
+                    """CREATE TABLE IF NOT EXISTS ql_folders (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        name TEXT NOT NULL,
+                        position INTEGER NOT NULL DEFAULT 0
+                    )"""
+                )
+            }
+        }
+
         fun getInstance(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
@@ -184,7 +199,7 @@ abstract class AppDatabase : RoomDatabase() {
                     .addMigrations(
                         MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4,
                         MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
-                        MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11
+                        MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12
                     )
                     .build().also { INSTANCE = it }
             }

--- a/app/src/main/java/com/mindfulhome/data/AppRepository.kt
+++ b/app/src/main/java/com/mindfulhome/data/AppRepository.kt
@@ -4,6 +4,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlin.math.max
 
+sealed class QuickLaunchGridKey {
+    data class App(val packageName: String) : QuickLaunchGridKey()
+    data class Folder(val folderId: Long) : QuickLaunchGridKey()
+}
+
 class AppRepository(private val database: AppDatabase) {
     private companion object {
         const val DEFAULT_HIDE_THRESHOLD = -2
@@ -16,6 +21,7 @@ class AppRepository(private val database: AppDatabase) {
     private val shelfDao = database.shelfDao()
     private val todoDao = database.todoDao()
     private val quickLaunchDao = database.quickLaunchDao()
+    private val qlFolderDao = database.quickLaunchFolderDao()
 
     // Karma
     fun allKarma(): Flow<List<AppKarma>> = karmaDao.getAllKarma()
@@ -215,6 +221,7 @@ class AppRepository(private val database: AppDatabase) {
 
     // QuickLaunch (default page only — separate from the home-screen favorites shelf)
     fun quickLaunchApps(): Flow<List<QuickLaunchItem>> = quickLaunchDao.getAll()
+    fun quickLaunchFolders(): Flow<List<QuickLaunchFolder>> = qlFolderDao.getAll()
 
     suspend fun addToQuickLaunch(packageName: String) {
         val nextPosition = quickLaunchDao.maxPosition() + 1
@@ -223,6 +230,61 @@ class AppRepository(private val database: AppDatabase) {
 
     suspend fun removeFromQuickLaunch(packageName: String) {
         quickLaunchDao.remove(packageName)
+    }
+
+    /** Persist new grid order after drag-and-drop. Each key is either an app packageName or a folder id. */
+    suspend fun reorderQuickLaunch(orderedKeys: List<QuickLaunchGridKey>) {
+        orderedKeys.forEachIndexed { index, key ->
+            when (key) {
+                is QuickLaunchGridKey.App -> quickLaunchDao.updatePosition(key.packageName, index)
+                is QuickLaunchGridKey.Folder -> qlFolderDao.updatePosition(key.folderId, index)
+            }
+        }
+    }
+
+    /**
+     * Create a folder from two top-level apps. The folder is placed at [folderPosition]
+     * (the target app's current grid position).
+     */
+    suspend fun createQuickLaunchFolder(pkg1: String, pkg2: String, folderPosition: Int): Long {
+        val folderId = qlFolderDao.insert(QuickLaunchFolder(name = "Folder", position = folderPosition))
+        quickLaunchDao.setFolder(pkg1, folderId)
+        quickLaunchDao.updatePosition(pkg1, 0)
+        quickLaunchDao.setFolder(pkg2, folderId)
+        quickLaunchDao.updatePosition(pkg2, 1)
+        return folderId
+    }
+
+    /** Add an existing top-level app into a folder. */
+    suspend fun addAppToQuickLaunchFolder(packageName: String, folderId: Long) {
+        val count = quickLaunchDao.countInFolder(folderId)
+        quickLaunchDao.setFolder(packageName, folderId)
+        quickLaunchDao.updatePosition(packageName, count)
+    }
+
+    suspend fun renameQuickLaunchFolder(folderId: Long, name: String) {
+        qlFolderDao.rename(folderId, name)
+    }
+
+    /** Remove an app from a folder; deletes the folder if it becomes empty. */
+    suspend fun removeAppFromQuickLaunchFolder(packageName: String, folderId: Long) {
+        val nextPos = quickLaunchDao.maxPosition() + 1
+        quickLaunchDao.setFolder(packageName, null)
+        quickLaunchDao.updatePosition(packageName, nextPos)
+        if (quickLaunchDao.countInFolder(folderId) == 0) {
+            qlFolderDao.delete(folderId)
+        }
+    }
+
+    /** Delete a folder and move all its apps back to top-level. */
+    suspend fun deleteQuickLaunchFolder(folderId: Long) {
+        val apps = quickLaunchDao.getInFolderOnce(folderId)
+        apps.forEach { item ->
+            val nextPos = quickLaunchDao.maxPosition() + 1
+            quickLaunchDao.setFolder(item.packageName, null)
+            quickLaunchDao.updatePosition(item.packageName, nextPos)
+        }
+        qlFolderDao.delete(folderId)
     }
 
     // Todo widget (integrated)

--- a/app/src/main/java/com/mindfulhome/data/QuickLaunchFolder.kt
+++ b/app/src/main/java/com/mindfulhome/data/QuickLaunchFolder.kt
@@ -1,0 +1,12 @@
+package com.mindfulhome.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "ql_folders")
+data class QuickLaunchFolder(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val name: String,
+    val position: Int = 0,
+)

--- a/app/src/main/java/com/mindfulhome/data/QuickLaunchItem.kt
+++ b/app/src/main/java/com/mindfulhome/data/QuickLaunchItem.kt
@@ -8,4 +8,5 @@ data class QuickLaunchItem(
     @PrimaryKey
     val packageName: String,
     val position: Int = 0,
+    val folderId: Long? = null,
 )

--- a/app/src/main/java/com/mindfulhome/ui/defaultpage/DefaultPageScreen.kt
+++ b/app/src/main/java/com/mindfulhome/ui/defaultpage/DefaultPageScreen.kt
@@ -2,11 +2,11 @@ package com.mindfulhome.ui.defaultpage
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Box
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -52,19 +53,34 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toSize
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.mindfulhome.AppVersion
 import com.mindfulhome.data.AppRepository
+import com.mindfulhome.data.QuickLaunchFolder
+import com.mindfulhome.data.QuickLaunchGridKey
 import com.mindfulhome.data.TodoItem
+import com.mindfulhome.model.AppInfo
 import com.mindfulhome.ui.common.AddAppsDialog
 import com.mindfulhome.util.PackageManagerHelper
 import java.text.DateFormat
@@ -72,6 +88,139 @@ import java.util.Calendar
 import java.util.Date
 import kotlinx.coroutines.launch
 import androidx.compose.foundation.BorderStroke
+import kotlin.math.roundToInt
+
+// ---------------------------------------------------------------------------
+// QuickLaunch grid data types
+// ---------------------------------------------------------------------------
+
+private sealed class QuickLaunchGridEntry {
+    abstract val sortPosition: Int
+    abstract val key: String
+
+    data class App(val appInfo: AppInfo, val position: Int) : QuickLaunchGridEntry() {
+        override val sortPosition = position
+        override val key = "app:${appInfo.packageName}"
+    }
+
+    data class Folder(
+        val folderId: Long,
+        val name: String,
+        val apps: List<AppInfo>,
+        val position: Int,
+    ) : QuickLaunchGridEntry() {
+        override val sortPosition = position
+        override val key = "folder:$folderId"
+    }
+}
+
+private fun buildQuickLaunchGridEntries(
+    allItems: List<com.mindfulhome.data.QuickLaunchItem>,
+    folders: List<QuickLaunchFolder>,
+    installedApps: List<AppInfo>,
+): List<QuickLaunchGridEntry> {
+    val appsByPackage = installedApps.associateBy { it.packageName }
+    val itemsByFolder = allItems.filter { it.folderId != null }.groupBy { it.folderId!! }
+
+    val appEntries = allItems
+        .filter { it.folderId == null }
+        .mapNotNull { item ->
+            val appInfo = appsByPackage[item.packageName] ?: return@mapNotNull null
+            QuickLaunchGridEntry.App(appInfo, item.position)
+        }
+
+    val folderEntries = folders.map { folder ->
+        val folderApps = (itemsByFolder[folder.id] ?: emptyList())
+            .sortedBy { it.position }
+            .mapNotNull { appsByPackage[it.packageName] }
+        QuickLaunchGridEntry.Folder(folder.id, folder.name, folderApps, folder.position)
+    }
+
+    return (appEntries + folderEntries).sortedBy { it.sortPosition }
+}
+
+// ---------------------------------------------------------------------------
+// Drag state
+// ---------------------------------------------------------------------------
+
+private class QuickLaunchDragState {
+    var isDragging by mutableStateOf(false)
+        private set
+    var draggedEntry: QuickLaunchGridEntry? by mutableStateOf(null)
+        private set
+    var draggedIndex: Int by mutableStateOf(-1)
+        private set
+    var overlayOffset by mutableStateOf(Offset.Zero)
+        private set
+    var hoverIndex by mutableStateOf(-1)
+        private set
+    var isLongHover by mutableStateOf(false)
+        private set
+
+    private val cellBounds = mutableMapOf<Int, Rect>()
+    private var fingerPos = Offset.Zero
+    private var grabOffset = Offset.Zero
+    private var hoverStartMs = 0L
+
+    fun registerCellBounds(index: Int, topLeft: Offset, size: Size) {
+        cellBounds[index] = Rect(topLeft, size)
+    }
+
+    fun startDrag(entry: QuickLaunchGridEntry, index: Int, itemTopLeft: Offset, localTouch: Offset) {
+        draggedEntry = entry
+        draggedIndex = index
+        grabOffset = localTouch
+        fingerPos = itemTopLeft + localTouch
+        overlayOffset = itemTopLeft
+        isDragging = true
+        hoverIndex = -1
+        isLongHover = false
+        hoverStartMs = 0L
+    }
+
+    fun updateDrag(delta: Offset) {
+        fingerPos += delta
+        overlayOffset = fingerPos - grabOffset
+
+        val newHover = cellBounds.entries
+            .filter { (idx, _) -> idx != draggedIndex }
+            .firstOrNull { (_, bounds) -> bounds.contains(fingerPos) }
+            ?.key ?: -1
+
+        if (newHover != hoverIndex) {
+            hoverIndex = newHover
+            hoverStartMs = if (newHover >= 0) System.currentTimeMillis() else 0L
+            isLongHover = false
+        } else if (hoverIndex >= 0) {
+            isLongHover = (System.currentTimeMillis() - hoverStartMs) >= 600L
+        }
+    }
+
+    fun endDrag(): Pair<Int, Boolean> {
+        val result = Pair(hoverIndex, isLongHover)
+        reset()
+        return result
+    }
+
+    fun cancelDrag() = reset()
+
+    private fun reset() {
+        isDragging = false
+        draggedEntry = null
+        draggedIndex = -1
+        overlayOffset = Offset.Zero
+        hoverIndex = -1
+        isLongHover = false
+        fingerPos = Offset.Zero
+        grabOffset = Offset.Zero
+        hoverStartMs = 0L
+        cellBounds.clear()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal state models
+// ---------------------------------------------------------------------------
 
 private data class TodoEditorState(
     val id: Long? = null,
@@ -80,6 +229,10 @@ private data class TodoEditorState(
     val deadlineEpochMs: Long? = null,
     val priority: Int = 2,
 )
+
+// ---------------------------------------------------------------------------
+// DefaultPageScreen
+// ---------------------------------------------------------------------------
 
 @Composable
 fun DefaultPageScreen(
@@ -97,181 +250,304 @@ fun DefaultPageScreen(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val haptic = LocalHapticFeedback.current
     val appVersion = AppVersion.versionName
-    val quickLaunchItems by repository.quickLaunchApps().collectAsState(initial = emptyList())
-    val todoItems by repository.sortedOpenTodos().collectAsState(initial = emptyList())
-    val quickLaunchPackages = remember(quickLaunchItems) { quickLaunchItems.map { it.packageName }.toSet() }
 
-    var installedApps by remember { mutableStateOf(emptyList<com.mindfulhome.model.AppInfo>()) }
+    val allQuickLaunchItems by repository.quickLaunchApps().collectAsState(initial = emptyList())
+    val quickLaunchFolders by repository.quickLaunchFolders().collectAsState(initial = emptyList())
+    val todoItems by repository.sortedOpenTodos().collectAsState(initial = emptyList())
+
+    val quickLaunchPackages = remember(allQuickLaunchItems) {
+        allQuickLaunchItems.map { it.packageName }.toSet()
+    }
+
+    var installedApps by remember { mutableStateOf(emptyList<AppInfo>()) }
     var showAddDialog by remember { mutableStateOf(false) }
     var isRemoveMode by remember { mutableStateOf(false) }
     var editor by remember { mutableStateOf<TodoEditorState?>(null) }
+    var openFolderEntry by remember { mutableStateOf<QuickLaunchGridEntry.Folder?>(null) }
+    var pendingFolderRename by remember { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(Unit) {
         installedApps = PackageManagerHelper.getInstalledApps(context)
     }
-
     LaunchedEffect(Unit) {
         onScreenShown()
     }
 
-    val quickLaunchApps = remember(installedApps, quickLaunchPackages) {
-        installedApps.filter { it.packageName in quickLaunchPackages }
+    val baseGridEntries = remember(allQuickLaunchItems, quickLaunchFolders, installedApps) {
+        buildQuickLaunchGridEntries(allQuickLaunchItems, quickLaunchFolders, installedApps)
+    }
+    val gridEntries = remember { mutableStateListOf<QuickLaunchGridEntry>() }
+    val dragState = remember { QuickLaunchDragState() }
+
+    LaunchedEffect(baseGridEntries) {
+        if (!dragState.isDragging) {
+            gridEntries.clear()
+            gridEntries.addAll(baseGridEntries)
+        }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .statusBarsPadding()
-            .navigationBarsPadding()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp, vertical = 10.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = "v$appVersion",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.weight(1f),
-            )
-            IconButton(onClick = onOpenLogs) {
-                Icon(
-                    Icons.AutoMirrored.Filled.Article,
-                    contentDescription = "Session logs",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            IconButton(onClick = onOpenKarma) {
-                Icon(
-                    Icons.Default.Stars,
-                    contentDescription = "Karma",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            IconButton(onClick = onOpenSettings) {
-                Icon(
-                    Icons.Default.Settings,
-                    contentDescription = "Settings",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
+    // Keep the open folder in sync with DB updates
+    val currentOpenFolder = openFolderEntry?.let { of ->
+        gridEntries.filterIsInstance<QuickLaunchGridEntry.Folder>().find { it.folderId == of.folderId }
+    }
 
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(14.dp),
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.6f)),
-            colors = CardDefaults.cardColors(
-                containerColor = androidx.compose.ui.graphics.Color.Transparent
-            ),
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(12.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        "Todo Widget",
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.weight(1f),
-                    )
-                    IconButton(
-                        onClick = {
-                            editor = TodoEditorState(
-                                deadlineEpochMs = next6pmEpochMs()
-                            )
-                        },
-                    ) {
-                        Icon(Icons.Default.Add, contentDescription = "Add todo")
+    fun handleDrop(dragged: QuickLaunchGridEntry, hoverIdx: Int, isLong: Boolean) {
+        val target = gridEntries.getOrNull(hoverIdx) ?: return
+        if (isLong && dragged is QuickLaunchGridEntry.App) {
+            when (target) {
+                is QuickLaunchGridEntry.App -> {
+                    // Create a new folder from two apps
+                    scope.launch {
+                        val folderId = repository.createQuickLaunchFolder(
+                            pkg1 = dragged.appInfo.packageName,
+                            pkg2 = target.appInfo.packageName,
+                            folderPosition = target.position,
+                        )
+                        pendingFolderRename = folderId
                     }
                 }
-                if (todoItems.isEmpty()) {
-                    Text(
-                        "No open items yet.",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                is QuickLaunchGridEntry.Folder -> {
+                    // Add app to existing folder
+                    scope.launch {
+                        repository.addAppToQuickLaunchFolder(dragged.appInfo.packageName, target.folderId)
+                    }
+                }
+            }
+        } else {
+            // Reorder
+            val fromIdx = gridEntries.indexOf(dragged)
+            val toIdx = hoverIdx
+            if (fromIdx >= 0 && toIdx >= 0 && fromIdx != toIdx) {
+                val moved = gridEntries.removeAt(fromIdx)
+                gridEntries.add(toIdx, moved)
+                scope.launch {
+                    repository.reorderQuickLaunch(gridEntries.map { entry ->
+                        when (entry) {
+                            is QuickLaunchGridEntry.App -> QuickLaunchGridKey.App(entry.appInfo.packageName)
+                            is QuickLaunchGridEntry.Folder -> QuickLaunchGridKey.Folder(entry.folderId)
+                        }
+                    })
+                }
+            }
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .verticalScroll(rememberScrollState(), enabled = !dragState.isDragging)
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "v$appVersion",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onOpenLogs) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.Article,
+                        contentDescription = "Session logs",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                } else {
-                    LazyColumn(
-                        modifier = Modifier.height(180.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                }
+                IconButton(onClick = onOpenKarma) {
+                    Icon(
+                        Icons.Default.Stars,
+                        contentDescription = "Karma",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                IconButton(onClick = onOpenSettings) {
+                    Icon(
+                        Icons.Default.Settings,
+                        contentDescription = "Settings",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(14.dp),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.6f)),
+                colors = CardDefaults.cardColors(
+                    containerColor = androidx.compose.ui.graphics.Color.Transparent
+                ),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        items(todoItems.take(6), key = { it.id }) { item ->
-                            TodoRow(
-                                item = item,
-                                onComplete = {
-                                    scope.launch { repository.setTodoCompleted(item.id, true) }
-                                },
-                                onEdit = {
-                                    editor = TodoEditorState(
-                                        id = item.id,
-                                        intent = item.intentText,
-                                        durationMinutes = item.expectedDurationMinutes?.toString() ?: "",
-                                        deadlineEpochMs = item.deadlineEpochMs,
-                                        priority = item.priority,
-                                    )
-                                },
-                                onStart = { onStartTodo(item.expectedDurationMinutes, item.intentText) },
+                        Text(
+                            "Todo Widget",
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        IconButton(
+                            onClick = {
+                                editor = TodoEditorState(deadlineEpochMs = next6pmEpochMs())
+                            },
+                        ) {
+                            Icon(Icons.Default.Add, contentDescription = "Add todo")
+                        }
+                    }
+                    if (todoItems.isEmpty()) {
+                        Text(
+                            "No open items yet.",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.height(180.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                        ) {
+                            items(todoItems.take(6), key = { it.id }) { item ->
+                                TodoRow(
+                                    item = item,
+                                    onComplete = {
+                                        scope.launch { repository.setTodoCompleted(item.id, true) }
+                                    },
+                                    onEdit = {
+                                        editor = TodoEditorState(
+                                            id = item.id,
+                                            intent = item.intentText,
+                                            durationMinutes = item.expectedDurationMinutes?.toString() ?: "",
+                                            deadlineEpochMs = item.deadlineEpochMs,
+                                            priority = item.priority,
+                                        )
+                                    },
+                                    onStart = { onStartTodo(item.expectedDurationMinutes, item.intentText) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (resumeSessionLabel != null && onResumeSession != null && resumeSessionMinutes > 0) {
+                OutlinedButton(
+                    onClick = onResumeSession,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(14.dp),
+                ) {
+                    Text("Resume $resumeSessionLabel (${formatMinutes(resumeSessionMinutes)})")
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "QuickLaunch",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                if (isRemoveMode) {
+                    TextButton(onClick = { isRemoveMode = false }) {
+                        Text("Done")
+                    }
+                } else {
+                    IconButton(onClick = { isRemoveMode = true }) {
+                        Icon(
+                            Icons.Default.Edit,
+                            contentDescription = "Edit QuickLaunch",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            QuickLaunchWrappedRow(
+                gridEntries = gridEntries,
+                dragState = dragState,
+                quickLaunchPackages = quickLaunchPackages,
+                onQuickLaunchApp = onQuickLaunchApp,
+                onAddQuickLaunch = { showAddDialog = true },
+                isRemoveMode = isRemoveMode,
+                onRemoveApp = { packageName ->
+                    scope.launch { repository.removeFromQuickLaunch(packageName) }
+                },
+                onRemoveFolder = { folderId ->
+                    scope.launch { repository.deleteQuickLaunchFolder(folderId) }
+                },
+                onOpenFolder = { folder -> openFolderEntry = folder },
+                onDrop = { hoverIdx, isLong ->
+                    val dragged = dragState.draggedEntry
+                    if (dragged != null) handleDrop(dragged, hoverIdx, isLong)
+                },
+                onDragStarted = { entry, index, itemTopLeft, localTouch ->
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    dragState.startDrag(entry, index, itemTopLeft, localTouch)
+                },
+                onDragDelta = { delta -> dragState.updateDrag(delta) },
+                onDragCancelled = { dragState.cancelDrag() },
+            )
+
+            Button(
+                onClick = onOpenTimerPlain,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("something else?")
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        // Floating drag overlay
+        if (dragState.isDragging) {
+            val dragged = dragState.draggedEntry
+            if (dragged != null) {
+                Box(
+                    modifier = Modifier
+                        .offset {
+                            IntOffset(
+                                dragState.overlayOffset.x.roundToInt(),
+                                dragState.overlayOffset.y.roundToInt(),
                             )
+                        }
+                        .size(74.dp)
+                        .graphicsLayer {
+                            scaleX = 1.15f
+                            scaleY = 1.15f
+                            shadowElevation = 8f
+                            alpha = 0.9f
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    when (dragged) {
+                        is QuickLaunchGridEntry.App -> {
+                            if (dragged.appInfo.icon != null) {
+                                Image(
+                                    painter = rememberDrawablePainter(dragged.appInfo.icon),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(42.dp),
+                                )
+                            }
+                        }
+                        is QuickLaunchGridEntry.Folder -> {
+                            FolderIconGrid(apps = dragged.apps, size = 42.dp)
                         }
                     }
                 }
             }
         }
-
-        if (resumeSessionLabel != null && onResumeSession != null && resumeSessionMinutes > 0) {
-            OutlinedButton(
-                onClick = onResumeSession,
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(14.dp),
-            ) {
-                Text("Resume $resumeSessionLabel (${formatMinutes(resumeSessionMinutes)})")
-            }
-        }
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = "QuickLaunch",
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.weight(1f),
-            )
-            if (isRemoveMode) {
-                TextButton(onClick = { isRemoveMode = false }) {
-                    Text("Done")
-                }
-            }
-        }
-
-        QuickLaunchWrappedRow(
-            quickLaunchApps = quickLaunchApps,
-            quickLaunchPackages = quickLaunchPackages,
-            onQuickLaunchApp = onQuickLaunchApp,
-            onAddQuickLaunch = { showAddDialog = true },
-            isRemoveMode = isRemoveMode,
-            onEnterRemoveMode = { isRemoveMode = true },
-            onRemoveApp = { packageName ->
-                scope.launch { repository.removeFromQuickLaunch(packageName) }
-            },
-        )
-
-        Button(
-            onClick = onOpenTimerPlain,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text("something else?")
-        }
-        Spacer(modifier = Modifier.height(12.dp))
     }
 
     if (showAddDialog) {
@@ -283,6 +559,36 @@ fun DefaultPageScreen(
                 scope.launch { repository.addToQuickLaunch(packageName) }
             },
             onDismiss = { showAddDialog = false },
+        )
+    }
+
+    // Folder rename dialog shown right after creating a folder via drag-and-drop
+    pendingFolderRename?.let { folderId ->
+        FolderRenameDialog(
+            initialName = "Folder",
+            onConfirm = { name ->
+                scope.launch { repository.renameQuickLaunchFolder(folderId, name) }
+                pendingFolderRename = null
+            },
+            onDismiss = { pendingFolderRename = null },
+        )
+    }
+
+    // Folder contents dialog
+    currentOpenFolder?.let { folder ->
+        FolderContentsDialog(
+            folder = folder,
+            onLaunchApp = { packageName ->
+                openFolderEntry = null
+                onQuickLaunchApp(packageName, quickLaunchPackages)
+            },
+            onRemoveFromFolder = { packageName ->
+                scope.launch { repository.removeAppFromQuickLaunchFolder(packageName, folder.folderId) }
+            },
+            onRename = { name ->
+                scope.launch { repository.renameQuickLaunchFolder(folder.folderId, name) }
+            },
+            onDismiss = { openFolderEntry = null },
         )
     }
 
@@ -309,21 +615,31 @@ fun DefaultPageScreen(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
+// ---------------------------------------------------------------------------
+// QuickLaunch grid
+// ---------------------------------------------------------------------------
+
 @Composable
 private fun QuickLaunchWrappedRow(
-    quickLaunchApps: List<com.mindfulhome.model.AppInfo>,
+    gridEntries: List<QuickLaunchGridEntry>,
+    dragState: QuickLaunchDragState,
     quickLaunchPackages: Set<String>,
     onQuickLaunchApp: (packageName: String, allowedPackages: Set<String>) -> Unit,
     onAddQuickLaunch: () -> Unit,
     isRemoveMode: Boolean,
-    onEnterRemoveMode: () -> Unit,
     onRemoveApp: (String) -> Unit,
+    onRemoveFolder: (Long) -> Unit,
+    onOpenFolder: (QuickLaunchGridEntry.Folder) -> Unit,
+    onDrop: (hoverIndex: Int, isLongHover: Boolean) -> Unit,
+    onDragStarted: (QuickLaunchGridEntry, Int, Offset, Offset) -> Unit,
+    onDragDelta: (Offset) -> Unit,
+    onDragCancelled: () -> Unit,
 ) {
     data class Tile(
-        val app: com.mindfulhome.model.AppInfo? = null,
+        val entry: QuickLaunchGridEntry? = null,
         val isAdd: Boolean = false,
         val isPlaceholder: Boolean = false,
+        val index: Int = -1,
     )
 
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
@@ -334,15 +650,14 @@ private fun QuickLaunchWrappedRow(
         } else {
             0.dp
         }
-        val rowChunks = remember(quickLaunchApps, columns) {
-            val base = (quickLaunchApps.map { Tile(app = it) } + Tile(isAdd = true))
-                .chunked(columns)
-            base.map { row ->
-                if (row.size >= columns) {
-                    row
-                } else {
-                    row + List(columns - row.size) { Tile(isPlaceholder = true) }
-                }
+
+        val tilesWithIndex = run {
+            val tiles = gridEntries.mapIndexed { idx, entry -> Tile(entry = entry, index = idx) } +
+                Tile(isAdd = true)
+            val rows = tiles.chunked(columns)
+            rows.map { row ->
+                if (row.size >= columns) row
+                else row + List(columns - row.size) { Tile(isPlaceholder = true) }
             }
         }
 
@@ -350,7 +665,7 @@ private fun QuickLaunchWrappedRow(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            rowChunks.forEach { rowTiles ->
+            tilesWithIndex.forEach { rowTiles ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(horizontalGap),
@@ -360,72 +675,89 @@ private fun QuickLaunchWrappedRow(
                             modifier = Modifier.weight(1f),
                             contentAlignment = Alignment.Center,
                         ) {
-                            val app = tile.app
                             when {
                                 tile.isPlaceholder -> {
-                                    Spacer(
-                                        modifier = Modifier
-                                            .width(minCellWidth)
-                                            .height(1.dp)
-                                    )
-                                }
-                                app != null -> {
-                                Box {
-                                    Column(
-                                        modifier = Modifier
-                                            .width(minCellWidth)
-                                            .combinedClickable(
-                                                onLongClick = onEnterRemoveMode,
-                                                onClick = {
-                                                    if (isRemoveMode) onRemoveApp(app.packageName)
-                                                    else onQuickLaunchApp(app.packageName, quickLaunchPackages)
-                                                },
-                                            ),
-                                        horizontalAlignment = Alignment.CenterHorizontally,
-                                    ) {
-                                        if (app.icon != null) {
-                                            Image(
-                                                painter = rememberDrawablePainter(app.icon),
-                                                contentDescription = app.label,
-                                                modifier = Modifier.size(42.dp),
-                                            )
-                                        }
-                                        Spacer(modifier = Modifier.height(2.dp))
-                                        Text(
-                                            text = app.label,
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
-                                            style = MaterialTheme.typography.labelSmall,
-                                        )
-                                    }
-                                    if (isRemoveMode) {
-                                        Box(
-                                            modifier = Modifier
-                                                .align(Alignment.TopEnd)
-                                                .size(18.dp)
-                                                .background(Color.Red, CircleShape),
-                                            contentAlignment = Alignment.Center,
-                                        ) {
-                                            Icon(
-                                                Icons.Default.Close,
-                                                contentDescription = "Remove",
-                                                modifier = Modifier.size(12.dp),
-                                                tint = Color.White,
-                                            )
-                                        }
-                                    }
-                                }
+                                    Spacer(modifier = Modifier.width(minCellWidth).height(1.dp))
                                 }
                                 tile.isAdd -> {
-                                OutlinedButton(
-                                    onClick = onAddQuickLaunch,
-                                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.6f)),
-                                    modifier = Modifier.width(minCellWidth),
-                                ) {
-                                    Icon(Icons.Default.Add, contentDescription = "Add QuickLaunch app")
+                                    OutlinedButton(
+                                        onClick = onAddQuickLaunch,
+                                        border = BorderStroke(
+                                            1.dp,
+                                            MaterialTheme.colorScheme.outline.copy(alpha = 0.6f),
+                                        ),
+                                        modifier = Modifier.width(minCellWidth),
+                                    ) {
+                                        Icon(Icons.Default.Add, contentDescription = "Add QuickLaunch app")
+                                    }
                                 }
+                                tile.entry != null -> {
+                                    val entry = tile.entry
+                                    val entryIndex = tile.index
+                                    val isDragged = dragState.draggedEntry?.key == entry.key
+                                    val isHoverTarget = dragState.hoverIndex == entryIndex
+                                    val isLongHoverTarget = isHoverTarget && dragState.isLongHover
+                                    var itemRootPosition by remember { mutableStateOf(Offset.Zero) }
+
+                                    val borderColor = when {
+                                        isLongHoverTarget -> MaterialTheme.colorScheme.tertiary
+                                        isHoverTarget -> MaterialTheme.colorScheme.primary
+                                        else -> Color.Transparent
+                                    }
+
+                                    Box(
+                                        modifier = Modifier
+                                            .width(minCellWidth)
+                                            .onGloballyPositioned { coords ->
+                                                val pos = coords.positionInRoot()
+                                                itemRootPosition = pos
+                                                dragState.registerCellBounds(entryIndex, pos, coords.size.toSize())
+                                            }
+                                            .graphicsLayer { alpha = if (isDragged) 0f else 1f }
+                                            .border(
+                                                width = if (isHoverTarget) 2.dp else 0.dp,
+                                                color = borderColor,
+                                                shape = RoundedCornerShape(10.dp),
+                                            )
+                                            .pointerInput(entry.key) {
+                                                detectDragGesturesAfterLongPress(
+                                                    onDragStart = { localOffset ->
+                                                        onDragStarted(entry, entryIndex, itemRootPosition, localOffset)
+                                                    },
+                                                    onDrag = { change, delta ->
+                                                        change.consume()
+                                                        onDragDelta(delta)
+                                                    },
+                                                    onDragEnd = {
+                                                        val (hoverIdx, isLong) = dragState.endDrag()
+                                                        onDrop(hoverIdx, isLong)
+                                                    },
+                                                    onDragCancel = { onDragCancelled() },
+                                                )
+                                            },
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        when (entry) {
+                                            is QuickLaunchGridEntry.App -> {
+                                                AppTile(
+                                                    entry = entry,
+                                                    isRemoveMode = isRemoveMode,
+                                                    quickLaunchPackages = quickLaunchPackages,
+                                                    onQuickLaunchApp = onQuickLaunchApp,
+                                                    onRemoveApp = onRemoveApp,
+                                                )
+                                            }
+                                            is QuickLaunchGridEntry.Folder -> {
+                                                FolderTile(
+                                                    entry = entry,
+                                                    isRemoveMode = isRemoveMode,
+                                                    onClick = { onOpenFolder(entry) },
+                                                    onRemove = { onRemoveFolder(entry.folderId) },
+                                                )
+                                            }
+                                        }
+                                    }
                                 }
-                                else -> {}
                             }
                         }
                     }
@@ -434,6 +766,255 @@ private fun QuickLaunchWrappedRow(
         }
     }
 }
+
+@Composable
+private fun AppTile(
+    entry: QuickLaunchGridEntry.App,
+    isRemoveMode: Boolean,
+    quickLaunchPackages: Set<String>,
+    onQuickLaunchApp: (String, Set<String>) -> Unit,
+    onRemoveApp: (String) -> Unit,
+) {
+    Box(
+        modifier = Modifier.clickable {
+            if (isRemoveMode) onRemoveApp(entry.appInfo.packageName)
+            else onQuickLaunchApp(entry.appInfo.packageName, quickLaunchPackages)
+        },
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            if (entry.appInfo.icon != null) {
+                Image(
+                    painter = rememberDrawablePainter(entry.appInfo.icon),
+                    contentDescription = entry.appInfo.label,
+                    modifier = Modifier.size(42.dp),
+                )
+            }
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = entry.appInfo.label,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+        if (isRemoveMode) {
+            RemoveBadge(modifier = Modifier.align(Alignment.TopEnd))
+        }
+    }
+}
+
+@Composable
+private fun FolderTile(
+    entry: QuickLaunchGridEntry.Folder,
+    isRemoveMode: Boolean,
+    onClick: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    Box(
+        modifier = Modifier.clickable { if (isRemoveMode) onRemove() else onClick() },
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Box(
+                modifier = Modifier
+                    .size(42.dp)
+                    .background(
+                        MaterialTheme.colorScheme.surfaceVariant,
+                        RoundedCornerShape(10.dp),
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                FolderIconGrid(apps = entry.apps, size = 36.dp)
+            }
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = entry.name,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+        if (isRemoveMode) {
+            RemoveBadge(modifier = Modifier.align(Alignment.TopEnd))
+        }
+    }
+}
+
+@Composable
+private fun FolderIconGrid(apps: List<AppInfo>, size: androidx.compose.ui.unit.Dp) {
+    val iconSize = size / 2.2f
+    val displayApps = apps.take(4)
+    val rows = when (displayApps.size) {
+        1 -> listOf(displayApps)
+        2 -> listOf(displayApps)
+        else -> listOf(displayApps.take(2), displayApps.drop(2).take(2))
+    }
+    Column(
+        modifier = Modifier.size(size),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        rows.forEach { rowApps ->
+            Row(
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                rowApps.forEach { app ->
+                    if (app.icon != null) {
+                        Image(
+                            painter = rememberDrawablePainter(app.icon),
+                            contentDescription = null,
+                            modifier = Modifier.size(iconSize).padding(1.dp),
+                        )
+                    } else {
+                        Spacer(modifier = Modifier.size(iconSize))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RemoveBadge(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(18.dp)
+            .background(Color.Red, CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            Icons.Default.Close,
+            contentDescription = "Remove",
+            modifier = Modifier.size(12.dp),
+            tint = Color.White,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Folder dialogs
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun FolderRenameDialog(
+    initialName: String,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf(initialName) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Name your folder") },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Folder name") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(name.trim().ifBlank { "Folder" }) }) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}
+
+@Composable
+private fun FolderContentsDialog(
+    folder: QuickLaunchGridEntry.Folder,
+    onLaunchApp: (String) -> Unit,
+    onRemoveFromFolder: (String) -> Unit,
+    onRename: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var isRenaming by remember { mutableStateOf(false) }
+    var nameInput by remember(folder.name) { mutableStateOf(folder.name) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            if (isRenaming) {
+                OutlinedTextField(
+                    value = nameInput,
+                    onValueChange = { nameInput = it },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            } else {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(folder.name, modifier = Modifier.weight(1f))
+                    IconButton(onClick = { isRenaming = true }) {
+                        Icon(Icons.Default.Edit, contentDescription = "Rename folder")
+                    }
+                }
+            }
+        },
+        text = {
+            if (folder.apps.isEmpty()) {
+                Text("No apps in this folder.", color = MaterialTheme.colorScheme.onSurfaceVariant)
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    folder.apps.forEach { app ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            if (app.icon != null) {
+                                Image(
+                                    painter = rememberDrawablePainter(app.icon),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(32.dp),
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                            }
+                            TextButton(
+                                onClick = { onLaunchApp(app.packageName) },
+                                modifier = Modifier.weight(1f),
+                            ) {
+                                Text(
+                                    text = app.label,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                            TextButton(onClick = { onRemoveFromFolder(app.packageName) }) {
+                                Text("Remove")
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            if (isRenaming) {
+                TextButton(
+                    onClick = {
+                        onRename(nameInput.trim().ifBlank { folder.name })
+                        isRenaming = false
+                    },
+                ) {
+                    Text("Save")
+                }
+            } else {
+                TextButton(onClick = onDismiss) { Text("Close") }
+            }
+        },
+        dismissButton = if (isRenaming) {
+            { TextButton(onClick = { isRenaming = false; nameInput = folder.name }) { Text("Cancel") } }
+        } else null,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Todo UI
+// ---------------------------------------------------------------------------
 
 @Composable
 private fun TodoRow(
@@ -535,6 +1116,10 @@ private fun TodoEditorDialog(
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
     )
 }
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
 
 private fun next6pmEpochMs(nowMs: Long = System.currentTimeMillis()): Long {
     val cal = Calendar.getInstance().apply {


### PR DESCRIPTION
- Long-press any QuickLaunch icon to start dragging; drop it on another
  position to reorder, or hold for 600ms to merge into a folder
- Drag an app onto an existing folder to add it to that folder
- Tap a folder to view its apps, rename it, remove individual apps, or
  launch directly from the folder sheet
- Edit mode (pencil button in header) for quick removal without dragging
- DB: added ql_folders table and folderId column to quick_launch_items
  (migration 11→12); new QuickLaunchFolderDao + repo methods for
  create/rename/delete folder and reorderQuickLaunch

https://claude.ai/code/session_018adngMk6P2xASFbwhShFGE